### PR TITLE
fixed blynk command entirely overriding sensor

### DIFF
--- a/Gas_sensor/Gas_sensor.ino
+++ b/Gas_sensor/Gas_sensor.ino
@@ -4,12 +4,12 @@
 
 // You should get Auth Token in the Blynk App.
 // Go to the Project Settings (nut icon).
-char auth[] = "";
+char auth[] = "eSmfIcFcORGmqTnF2XPOCLDrrTT-Z66p";
 
 // Your WiFi credentials.
 // Set password to "" for open networks.
-char ssid[] = "";
-char pass[] = "";
+char ssid[] = "6П";
+char pass[] = "plsnosteal";
 
 #define MQ2A 34
 #define RELAY 26
@@ -21,6 +21,10 @@ int sensorValueA = 0;
 const int defaultDangerLevel = 1500;
 int dangerLevel = defaultDangerLevel;
 unsigned long last_stop = 0;
+
+BLYNK_WRITE(V1) {
+  dangerLevel = 1000 + 2 * (1023 - param.asInt());
+}
  
 void setup()
 {
@@ -44,7 +48,9 @@ void readRemoteInput()
 void readSensor()
 {
   sensorValueA = analogRead(MQ2A);
+  Serial.println("-------------------");
   Serial.println(sensorValueA);
+  Serial.printf("alarm trigger %i\n", dangerLevel);
  
   if (sensorValueA > dangerLevel)
   {

--- a/Gas_sensor/Gas_sensor.ino
+++ b/Gas_sensor/Gas_sensor.ino
@@ -4,12 +4,12 @@
 
 // You should get Auth Token in the Blynk App.
 // Go to the Project Settings (nut icon).
-char auth[] = "auth_key";
+char auth[] = "";
 
 // Your WiFi credentials.
 // Set password to "" for open networks.
-char ssid[] = "wifi_name";
-char pass[] = "wifi_pass";
+char ssid[] = "";
+char pass[] = "";
 
 #define MQ2A 34
 #define RELAY 26
@@ -29,17 +29,15 @@ void setup()
  pinMode(RELAY, OUTPUT);
  Blynk.begin(auth, ssid, pass);
  timer.setInterval(500L, readSensor); // read sensors every 500ms
- timer.setInterval(500L, readRemoteInput); // read data from mobile device every 500ms
+ timer.setInterval(100L, readRemoteInput); // read data from mobile device every 100ms
 }
 
 void readRemoteInput()
 {
   boolean isPressed = (digitalRead(BTN_PIN) == LOW);
   if (!isPressed) {
-    digitalWrite(RELAY, HIGH);
+    Serial.println("muted");
     last_stop = millis();
-  } else {
-    digitalWrite(RELAY, LOW);
   }
 }
 
@@ -50,10 +48,13 @@ void readSensor()
  
   if (sensorValueA > dangerLevel)
   {
-    if(millis() - last_stop < 10000)
+    if(millis() - last_stop > 10000)
     {
       digitalWrite(RELAY, LOW);
       Serial.println("Current Flowing");
+    } else {
+      Serial.println("muted, time remaining:");
+      Serial.println(10000 - (millis() - last_stop));
     }
   }
  


### PR DESCRIPTION
the button used to allow current through the relay when it was not pressed, regardless of sensor readings. Now it simply blocks current for 10s after pressing.